### PR TITLE
Sort fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ vendor/
 # Ignore mac files 
 .DS_Store
 
-# temporarily ignore gemfile.lock
-# Gemfile.lock
+# ignore gemfile.lock
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,20 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-# gem "github-pages"
-#
-# Issue: github-pages Gem doesn't work with Ruby 3!
-# This Gemfile should include the line commented out above.
-# The lines below are added as a work around for Ruby 3.
-# If you are doing serious customization and need to keep in sync with github-pages versions,
-# Please use Ruby 2.7x,
-# uncomment gem "github-pages" 
-# and delete the lines below.
+source 'https://rubygems.org'
 
-gem "jekyll"
+# needed for Jekyll
+gem 'jekyll'
+gem 'webrick'
+gem 'logger'
+gem 'base64'
+gem 'ostruct'
 
-gem "webrick", "~> 1.7"
-
-gem "csv"
+# needed for Rake tasks
+gem 'rake'
+gem 'csv'
+gem 'fileutils'
+gem 'mini_magick'
+unless Gem.win_platform?
+  gem 'image_optim'
+  gem 'image_optim_pack'
+end

--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -944,13 +944,25 @@ function shuffle(array) {
  * Sort items by specified field
  */
 function sorting(jsonObject, keyToSortBy) {
+    let descending = false;
+    let sortKey = keyToSortBy;
+
+    if (typeof keyToSortBy === 'string' && keyToSortBy.endsWith('_desc')) {
+        descending = true;
+        sortKey = keyToSortBy.slice(0, -5);
+    }
+
     jsonObject.sort((a, b) => {
-        let x = a[keyToSortBy];
-        let y = b[keyToSortBy];
+        let x = a[sortKey];
+        let y = b[sortKey];
         if (typeof x === 'string') x = x.toUpperCase();
         if (typeof y === 'string') y = y.toUpperCase();
         return (x == null) ? 1 : (y == null) ? -1 : (x < y) ? -1 : (x > y) ? 1 : 0;
     });
+
+    if (descending) {
+        jsonObject.reverse();
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixed #140 by inserting JS that searches for "date_desc" filter and reverses the sort order. This appears to work correctly on both Chrome and Safari now.

I also updated the Gemfile to include an update from the [collectionbuilder-csv](https://github.com/CollectionBuilder/collectionbuilder-csv/blob/main/Gemfile) template repository, which may help with some of the Ruby issues.

Relatedly, I added Gemfile.lock back into the .gitignore file so that site builds should work locally no matter our particular environment setup. @mhunter52 When I have a chance, can I look at your Ruby setup? I think I may have figured out your issue.