### PR TITLE
Fix broken 1942 land use tile layer on the Layered Map

### DIFF
--- a/_includes/js/layeredmap-js.html
+++ b/_includes/js/layeredmap-js.html
@@ -575,7 +575,7 @@
             { name: "1937 HOLC", layer: L.tileLayer('https://mapwarper.net/maps/tile/90758/{z}/{x}/{y}.png', {
                  attribution: 'Mapping Inequality'
             }), year: 1937 },
-            { name: "1942 land use", layer: L.tileLayer('https://mapwarper.net/maps/tile/94403/{z}/{x}/{y}.png', {
+            { name: "1942 land use", layer: L.tileLayer('https://mapwarper.net/maps/tile/110164/{z}/{x}/{y}.png', {
                  attribution: 'Free Library of Philadelphia'
             }), year: 1942 },
             { name: "1949 USGS", layer: L.tileLayer('https://mapwarper.net/maps/tile/88564/{z}/{x}/{y}.png', {


### PR DESCRIPTION
The MapWarper tile source for the "1942 land use" layer (map ID 94403) was returning HTTP 500 at every zoom level - confirmed by fetching the tile URL directly, independent of the site's JS. 

The map was re-warped and re-uploaded to MapWarper under a new ID (110164), which serves real tile imagery; verified the new tile URL directly before landing this.

Issues persist with registration - imagery appears 100m South of its real world location.